### PR TITLE
Corrects packageId/name configuration and handles error gracefully

### DIFF
--- a/lib/launchApplication.js
+++ b/lib/launchApplication.js
@@ -10,10 +10,13 @@ const configUtil = require('./configUtil');
 const { getTizenTvOutputCommand } = require('./outputCommander');
 const { logger } = require('./logger');
 
+const logInfo = (msg) => logger.log(`TizenTV: ${msg}`);
+const logError = (msg) => logger.error(`TizenTV: ${msg}`);
+
 module.exports = async function launchApplication(isDebug, wgtFilePath) {
     getTizenTvOutputCommand().show(true);
 
-    logger.log(`Launch Application${isDebug ? ' with debug' : ''}`);
+    logInfo(`Launch Application${isDebug ? ' with debug' : ''}`);
     let controller = new StepController();
     if (isDebug) {
         controller.addStep({
@@ -38,7 +41,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
     let webApp;
     if (wgtFilePath) {
         if (!fs.existsSync(wgtFilePath)) {
-            logger.error('Invalid `.wgt` file reference specified.');
+            logError('Invalid `.wgt` file reference specified.');
             return;
         }
         // Decompress .wgt package and read config.xml file content to get package id
@@ -49,13 +52,13 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
         if (configFile && configFile.length > 0) {
             xml2js.parseString(configFile[0].data.toString(), function (error, result) {
                 if (error) {
-                    logger.error(`Error occurred while processing \`config.xml\`, ${err}`);
+                    logError(`Error occurred while processing \`config.xml\`, ${err}`);
                 }
                 configJson = result;
             });
         }
         if (!configJson) {
-            logger.error('Invalid `.wgt` package file selected. Package parsing failed.');
+            logError('Invalid `.wgt` package file selected. Package parsing failed.');
             return;
         }
         // get the application id from `config.xml`
@@ -66,7 +69,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
     } else {
         webApp = TVWebApp.openProject(vscode.workspace.rootPath);
         if (!webApp) {
-            logger.log('launchApplication:web App is null');
+            logError('webApp is null');
             return;
         }
     }
@@ -75,44 +78,50 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
     let chromeExecPath = null;
     switch (results[0]) {
         case 'Debug On TV':
-            logger.log('launchApplication:Debug On TV');
+            logInfo('Debug On TV');
             chromeExecPath = configUtil.getConfig(configUtil.CHROME_EXEC);
             if (!chromeExecPath) {
                 chromeExecPath = await configUtil.userInputConfig(
                     configUtil.CHROME_EXEC
                 );
             }
+            logInfo(`Chrome application path :: ${chromeExecPath}`);
+
         case 'Run On TV':
-            logger.log('launchApplication:Run On TV');
+            logInfo('Run On TV');
             targetIP = configUtil.getConfig(configUtil.TARGET_IP);
             if (!targetIP) {
                 targetIP = await configUtil.userInputConfig(
                     configUtil.TARGET_IP
                 );
             }
-
+            logInfo(`TV IP Address :: ${targetIP}`);
             try {
                 await webApp.launchOnTV(targetIP, chromeExecPath, isDebug);
+                logInfo('Application launched');
+                vscode.window.showInformationMessage(`Launched '${webApp.id}.${webApp.name}' on ${targetIP}.`);
             } catch(error) {
-                logger.log('launchApplication: Failed to launch application');
-                logger.log('launchApplication: Error: ' + error)
+                logError('Failed to launch application');
+                vscode.window.showErrorMessage(`TizenTV: ${error.toString()}`);
             }
-
             break;
         case 'Debug On TV Emulator':
-            logger.log('launchApplication:Debug On TV Emulator');
+            logInfo('Debug On TV Emulator');
             chromeExecPath = configUtil.getConfig(configUtil.CHROME_EXEC);
             if (!chromeExecPath) {
                 chromeExecPath = await configUtil.userInputConfig(
                     configUtil.CHROME_EXEC
                 );
             }
+            logInfo(`Chrome executable path :: ${chromeExecPath}`);
+
         case 'Run On TV Emulator':
-            logger.log('launchApplication:Run On TV Emulator');
+            logInfo('Run On TV Emulator');
             webApp.launchOnEmulator(chromeExecPath, isDebug);
+            logInfo('Application launched');
             break;
         case 'Run On TV Simulator':
-            logger.log('launchApplication:Run On TV Simulator');
+            logInfo('Run On TV Simulator');
             let simulatorExecPath = configUtil.getConfig(
                 configUtil.SIMULATOR_EXEC
             );
@@ -121,7 +130,9 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
                     configUtil.CHROME_EXEC
                 );
             }
+            logInfo(`Simulator executable path :: ${simulatorExecPath}`);
             webApp.launchOnSimulator(simulatorExecPath);
+            logInfo('Application launched');
             break;
     }
 };

--- a/lib/launchApplication.js
+++ b/lib/launchApplication.js
@@ -62,7 +62,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
         const applicationId = configJson.widget['tizen:application'][0]['$'].id;
         const [packageId, name] = applicationId.split('.');
 
-        webApp = new TVWebApp(packageId, path.dirname(wgtFilePath), name);
+        webApp = new TVWebApp(name, path.dirname(wgtFilePath), packageId);
     } else {
         webApp = TVWebApp.openProject(vscode.workspace.rootPath);
         if (!webApp) {

--- a/lib/launchApplication.js
+++ b/lib/launchApplication.js
@@ -65,7 +65,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
         webApp = new TVWebApp(packageId, path.dirname(wgtFilePath), name);
     } else {
         webApp = TVWebApp.openProject(vscode.workspace.rootPath);
-        if (webApp == null) {
+        if (!webApp) {
             logger.log('launchApplication:web App is null');
             return;
         }
@@ -77,7 +77,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
         case 'Debug On TV':
             logger.log('launchApplication:Debug On TV');
             chromeExecPath = configUtil.getConfig(configUtil.CHROME_EXEC);
-            if (chromeExecPath == null) {
+            if (!chromeExecPath) {
                 chromeExecPath = await configUtil.userInputConfig(
                     configUtil.CHROME_EXEC
                 );
@@ -85,17 +85,24 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
         case 'Run On TV':
             logger.log('launchApplication:Run On TV');
             targetIP = configUtil.getConfig(configUtil.TARGET_IP);
-            if (targetIP == null) {
+            if (!targetIP) {
                 targetIP = await configUtil.userInputConfig(
                     configUtil.TARGET_IP
                 );
             }
-            await webApp.launchOnTV(targetIP, chromeExecPath, isDebug);
+
+            try {
+                await webApp.launchOnTV(targetIP, chromeExecPath, isDebug);
+            } catch(error) {
+                logger.log('launchApplication: Failed to launch application');
+                logger.log('launchApplication: Error: ' + error)
+            }
+
             break;
         case 'Debug On TV Emulator':
             logger.log('launchApplication:Debug On TV Emulator');
             chromeExecPath = configUtil.getConfig(configUtil.CHROME_EXEC);
-            if (chromeExecPath == null) {
+            if (!chromeExecPath) {
                 chromeExecPath = await configUtil.userInputConfig(
                     configUtil.CHROME_EXEC
                 );
@@ -109,7 +116,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
             let simulatorExecPath = configUtil.getConfig(
                 configUtil.SIMULATOR_EXEC
             );
-            if (simulatorExecPath == null) {
+            if (!simulatorExecPath) {
                 simulatorExecPath = await configUtil.userInputConfig(
                     configUtil.CHROME_EXEC
                 );

--- a/lib/launchApplication.js
+++ b/lib/launchApplication.js
@@ -95,7 +95,7 @@ module.exports = async function launchApplication(isDebug, wgtFilePath) {
                     configUtil.TARGET_IP
                 );
             }
-            logInfo(`TV IP Address :: ${targetIP}`);
+            logInfo(`Target IP :: ${targetIP}`);
             try {
                 await webApp.launchOnTV(targetIP, chromeExecPath, isDebug);
                 logInfo('Application launched');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tizentv",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tizentv",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "hasInstallScript": true,
       "dependencies": {
         "@tizentv/webide-common-tizentv": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "tizentv",
   "description": "'tizentv' is a lightweight dispatch of Tizen Studio, which provides extensible IDE to develop/debug tizen apps in vs code.",
   "icon": "images/icon.png",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "publisher": "tizensdk",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Changes / Fixes**

- For `TVWebApp` object, packageId/name configuration is incorrect. First parameter accepts `name` (not `packageId`)
- Handles error gracefully and propagates the same to logger instance
- Checks for `null` and `''` empty string both for configuration.
- Adds logger statement whenever necessary and makes output string consistent.